### PR TITLE
Add index_root parameter to from_pretrained

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Loading a model with `byaldi` is extremely straightforward:
 
 ```python3
 from byaldi import RAGMultiModalModel
+# Optionally, you can specify an `index_root`, which is where it'll save the index. It defaults to ".byaldi/".
 RAG = RAGMultiModalModel.from_pretrained("vidore/colpali")
 ```
 
@@ -75,8 +76,8 @@ Creating an index with `byaldi` is simple and flexible. **You can index a single
 
 ```python3
 from byaldi import RAGMultiModalModel
+# Optionally, you can specify an `index_root`, which is where it'll save the index. It defaults to ".byaldi/".
 RAG = RAGMultiModalModel.from_pretrained("vidore/colpali")
-# Optionally, you can specify an `index_root`, which is where it'll look for the index. It defaults to ".byaldi/".
 RAG.index(
     input_path="docs/", # The path to your documents
     index_name=index_name, # The name you want to give to your index. It'll be saved at `index_root/index_name/`.

--- a/byaldi/RAGModel.py
+++ b/byaldi/RAGModel.py
@@ -36,6 +36,7 @@ class RAGMultiModalModel:
     def from_pretrained(
         cls,
         pretrained_model_name_or_path: Union[str, Path],
+        index_root: str = ".byaldi",
         device: str = "cuda",
         verbose: int = 1,
     ):
@@ -50,7 +51,7 @@ class RAGMultiModalModel:
         """
         instance = cls()
         instance.model = ColPaliModel.from_pretrained(
-            pretrained_model_name_or_path, device=device, verbose=verbose
+            pretrained_model_name_or_path, index_root=index_root, device=device, verbose=verbose
         )
         return instance
 

--- a/byaldi/colpali.py
+++ b/byaldi/colpali.py
@@ -165,6 +165,7 @@ class ColPaliModel:
         n_gpu: int = -1,
         verbose: int = 1,
         device: Optional[Union[str, torch.device]] = None,
+        index_root: str = ".byaldi",
         **kwargs,
     ):
         return cls(
@@ -172,6 +173,7 @@ class ColPaliModel:
             n_gpu=n_gpu,
             verbose=verbose,
             load_from_index=False,
+            index_root=index_root,
             device=device,
             **kwargs,
         )


### PR DESCRIPTION
Currently the index_root cannot be set using RAGMultiModalModel.from_pretrained - the index has to be saved to the .byaldi default. This pull request adds the index_root parameter to RAGMultiModalModel.from_pretrained and ColPaliModel.from_pretrained, and adjusts the wording on the README about index_root as well.