### PR TITLE
Add LangChain Integration

### DIFF
--- a/byaldi/RAGModel.py
+++ b/byaldi/RAGModel.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from langchain_core.retrievers import BaseRetriever
-
 from PIL import Image
 
 from byaldi.colpali import ColPaliModel

--- a/byaldi/RAGModel.py
+++ b/byaldi/RAGModel.py
@@ -1,12 +1,17 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from langchain_core.retrievers import BaseRetriever
 from PIL import Image
 
 from byaldi.colpali import ColPaliModel
-from byaldi.integrations import ByaldiLangChainRetriever
+
 from byaldi.objects import Result
+
+# Optional langchain integration
+try:
+    from byaldi.integrations import ByaldiLangChainRetriever
+except ImportError:
+    pass
 
 
 class RAGMultiModalModel:
@@ -52,7 +57,10 @@ class RAGMultiModalModel:
         """
         instance = cls()
         instance.model = ColPaliModel.from_pretrained(
-            pretrained_model_name_or_path, index_root=index_root, device=device, verbose=verbose
+            pretrained_model_name_or_path,
+            index_root=index_root,
+            device=device,
+            verbose=verbose,
         )
         return instance
 
@@ -168,5 +176,5 @@ class RAGMultiModalModel:
     def get_doc_ids_to_file_names(self):
         return self.model.get_doc_ids_to_file_names()
 
-    def as_langchain_retriever(self, **kwargs: Any) -> BaseRetriever:
+    def as_langchain_retriever(self, **kwargs: Any):
         return ByaldiLangChainRetriever(model=self, kwargs=kwargs)

--- a/byaldi/RAGModel.py
+++ b/byaldi/RAGModel.py
@@ -1,9 +1,12 @@
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
+
+from langchain_core.retrievers import BaseRetriever
 
 from PIL import Image
 
 from byaldi.colpali import ColPaliModel
+from byaldi.integrations import ByaldiLangChainRetriever
 from byaldi.objects import Result
 
 
@@ -165,3 +168,6 @@ class RAGMultiModalModel:
 
     def get_doc_ids_to_file_names(self):
         return self.model.get_doc_ids_to_file_names()
+
+    def as_langchain_retriever(self, **kwargs: Any) -> BaseRetriever:
+        return ByaldiLangChainRetriever(model=self, kwargs=kwargs)

--- a/byaldi/integrations/__init__.py
+++ b/byaldi/integrations/__init__.py
@@ -1,0 +1,3 @@
+from byaldi.integrations._langchain import ByaldiLangChainRetriever
+
+__all__ = ["ByaldiLangChainRetriever"]

--- a/byaldi/integrations/__init__.py
+++ b/byaldi/integrations/__init__.py
@@ -1,3 +1,8 @@
-from byaldi.integrations._langchain import ByaldiLangChainRetriever
+_all__ = []
 
-__all__ = ["ByaldiLangChainRetriever"]
+try:
+    from byaldi.integrations._langchain import ByaldiLangChainRetriever
+
+    _all__.append("ByaldiLangChainRetriever")
+except ImportError:
+    pass

--- a/byaldi/integrations/_langchain.py
+++ b/byaldi/integrations/_langchain.py
@@ -1,0 +1,20 @@
+from typing import Any, List
+
+from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
+from langchain_core.retrievers import BaseRetriever
+
+from byaldi.objects import Result
+
+class ByaldiLangChainRetriever(BaseRetriever):
+    model: Any
+    kwargs: dict = {}
+
+    def _get_relevant_documents(
+        self,
+        query: str,
+        *,
+        run_manager: CallbackManagerForRetrieverRun,  # noqa
+    ) -> List[Result]:
+        """Get documents relevant to a query."""
+        docs = self.model.search(query, **self.kwargs)
+        return docs

--- a/byaldi/integrations/_langchain.py
+++ b/byaldi/integrations/_langchain.py
@@ -5,6 +5,7 @@ from langchain_core.retrievers import BaseRetriever
 
 from byaldi.objects import Result
 
+
 class ByaldiLangChainRetriever(BaseRetriever):
     model: Any
     kwargs: dict = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "srsly",
     "torch",
     "transformers",
+    "langchain-core",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,12 @@ dependencies = [
     "srsly",
     "torch",
     "transformers",
-    "langchain-core",
 ]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.4.0", "ruff>=0.1.9"]
 server = ["uvicorn", "fastapi"]
+langchain = ["langchain-core"]
 
 [project.urls]
 "Homepage" = "https://github.com/answerdotai/byaldi"


### PR DESCRIPTION
Adding the possibility to convert a RAGMultiModalModel into a LangChain BaseRetriever by following the [RAGatouille integrations](https://github.com/AnswerDotAI/RAGatouille/tree/main/ragatouille/integrations) code architecture.