### PR TITLE
[bugfix] Fix logic bug to make  `device` argument be respected when passed in

### DIFF
--- a/byaldi/colpali.py
+++ b/byaldi/colpali.py
@@ -49,9 +49,9 @@ class ColPaliModel:
         self.model_name = self.pretrained_model_name_or_path
         self.n_gpu = torch.cuda.device_count() if n_gpu == -1 else n_gpu
         device = (
-            device or ("cuda"
-            if torch.cuda.is_available()
-            else "mps" if torch.backends.mps.is_available() else "cpu")
+            device or (
+                "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
+            )
         )
         self.index_name = index_name
         self.verbose = verbose

--- a/byaldi/colpali.py
+++ b/byaldi/colpali.py
@@ -49,9 +49,9 @@ class ColPaliModel:
         self.model_name = self.pretrained_model_name_or_path
         self.n_gpu = torch.cuda.device_count() if n_gpu == -1 else n_gpu
         device = (
-            device or "cuda"
+            device or ("cuda"
             if torch.cuda.is_available()
-            else "mps" if torch.backends.mps.is_available() else "cpu"
+            else "mps" if torch.backends.mps.is_available() else "cpu")
         )
         self.index_name = index_name
         self.verbose = verbose


### PR DESCRIPTION
Why
===

Currently if you pass in the `device` arg to `from_pretrained`, there is a logic bug which makes it get resolved to something else unnecessarily based on the device available. 

For example, to reproduce, pass in `device="cpu"` on an Mac and it can resolved to "mps".

Turns out its just a bug in terms of logic in  how the device is being set .


What Changed
===

Fixed in this PR. 