### PR TITLE
Fix langchain integration not present in pypi tar & whl-- pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["byaldi"]
+[tool.setuptools.packages.find]
+include = ["byaldi*"]
 
 [project]
 name = "Byaldi"


### PR DESCRIPTION
The [tool.setuptools.packages.find] configuration with the include pattern include = ["byaldi*"] instructs setuptools to automatically discover all packages and subpackages under byaldi. The wildcard asterisk (*) matches any subpackage within byaldi, including structures like byaldi, byaldi.integrations, byaldi.subpackage, and more. This configuration automatically includes all nested subdirectories as Python packages, provided they contain an __init__.py file, which reduces manual maintenance since each subpackage does not need to be listed explicitly.